### PR TITLE
[codex] Add link to T-Invest OpenAPI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,3 +37,8 @@
 - `config/` — конфигурация Symfony.
 - `tests/` — тесты.
 - `var/` — временные файлы и логи (создаётся во время работы приложения).
+
+## T-Invest API
+
+- Для реализации Tools используйте схему OpenAPI, доступную по адресу:
+  https://russianinvestments.github.io/investAPI/swagger-ui/openapi.yaml


### PR DESCRIPTION
### Summary
- добавлена ссылка на T-Invest OpenAPI в `AGENTS.md`

### Testing
- `./bin/phpunit` *(failed: /usr/bin/env: ‘php’: No such file or directory)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684c37f257e083209ea8590b8a14c0b0