### PR TITLE
[codex] Add test environment server

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,6 @@
 # define your env variables for the test env here
 KERNEL_CLASS='App\Kernel'
 APP_SECRET='$ecretf0rt3st'
+APP_T_INVEST_TOKEN=dummy
+APP_T_INVEST_BASE_URL=https://localhost/
+APP_T_INVEST_ACCOUNT_ID=2019246368

--- a/config/services_test.yaml
+++ b/config/services_test.yaml
@@ -1,0 +1,4 @@
+services:
+    App\Tests\Fake\OperationsServiceComponentFake:
+        autowire: true
+    App\Component\OperationsService\OperationsServiceComponentInterface: '@App\Tests\Fake\OperationsServiceComponentFake'

--- a/tests/Fake/OperationsServiceComponentFake.php
+++ b/tests/Fake/OperationsServiceComponentFake.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Tests\Fake;
+
+use App\Component\OperationsService\Dto\GetPortfolioRequestDto;
+use App\Component\OperationsService\Dto\GetPortfolioResponseDto;
+use App\Component\OperationsService\Mapper\GetPortfolioResponseMapper;
+use App\Component\OperationsService\OperationsServiceComponentInterface;
+
+class OperationsServiceComponentFake implements OperationsServiceComponentInterface
+{
+    public function __construct(private GetPortfolioResponseMapper $mapper)
+    {
+    }
+
+    public function getPortfolio(GetPortfolioRequestDto $request): GetPortfolioResponseDto
+    {
+        $json = <<<'JSON'
+{"totalAmountShares":{},"totalAmountBonds":{},"totalAmountEtf":{},"totalAmountCurrencies":{},"totalAmountFutures":{},"expectedYield":{},"positions":[{"figi":"BBG00K53FBX6","instrumentType":"bond","quantity":{},"averagePositionPrice":{},"expectedYield":{},"currentNkd":{},"averagePositionPricePt":{},"currentPrice":{},"averagePositionPriceFifo":{},"quantityLots":{},"blocked":false,"blockedLots":{},"positionUid":"61bdcdb2-5733-4cf9-bb6a-7c2b975f3109","instrumentUid":"0160ee09-4b13-42d3-80f7-1482620820ea","varMargin":{},"expectedYieldFifo":{},"dailyYield":{},"ticker":"SU26224RMFS4"}],"accountId":"2019246368","totalAmountOptions":{},"totalAmountSp":{},"totalAmountPortfolio":{},"virtualPositions":[],"dailyYield":{},"dailyYieldRelative":{}}
+JSON;
+        $data = json_decode($json, true);
+
+        $fillMoney = static fn(?array $money): array => [
+            'currency' => $money['currency'] ?? 'RUB',
+            'units' => $money['units'] ?? 0,
+            'nano' => $money['nano'] ?? 0,
+        ];
+        $fillQuotation = static fn(?array $q): array => [
+            'units' => $q['units'] ?? 0,
+            'nano' => $q['nano'] ?? 0,
+        ];
+
+        foreach ([
+            'totalAmountShares',
+            'totalAmountBonds',
+            'totalAmountEtf',
+            'totalAmountCurrencies',
+            'totalAmountFutures',
+            'expectedYield',
+            'totalAmountOptions',
+            'totalAmountSp',
+            'totalAmountPortfolio',
+            'dailyYield',
+        ] as $field) {
+            $data[$field] = $fillMoney($data[$field] ?? []);
+        }
+        $data['dailyYieldRelative'] = $fillQuotation($data['dailyYieldRelative'] ?? []);
+
+        foreach ($data['positions'] as &$p) {
+            $p['quantity'] = $fillQuotation($p['quantity'] ?? []);
+            $p['averagePositionPrice'] = $fillMoney($p['averagePositionPrice'] ?? []);
+            $p['expectedYield'] = $fillQuotation($p['expectedYield'] ?? []);
+            $p['currentNkd'] = $fillMoney($p['currentNkd'] ?? []);
+            $p['averagePositionPricePt'] = $fillMoney($p['averagePositionPricePt'] ?? []);
+            $p['currentPrice'] = $fillMoney($p['currentPrice'] ?? []);
+            $p['averagePositionPriceFifo'] = $fillMoney($p['averagePositionPriceFifo'] ?? []);
+            $p['quantityLots'] = $fillQuotation($p['quantityLots'] ?? []);
+            $p['blockedLots'] = $fillQuotation($p['blockedLots'] ?? []);
+            $p['varMargin'] = $fillMoney($p['varMargin'] ?? []);
+            $p['expectedYieldFifo'] = $fillQuotation($p['expectedYieldFifo'] ?? []);
+            $p['dailyYield'] = $fillMoney($p['dailyYield'] ?? []);
+        }
+        unset($p);
+
+        return $this->mapper->map($data);
+    }
+}

--- a/tests/Integration/Command/ServerCommandTest.php
+++ b/tests/Integration/Command/ServerCommandTest.php
@@ -21,6 +21,9 @@ class ServerCommandTest extends KernelTestCase
                 args: [
                     'app:mcp-server',
                 ],
+                env: [
+                    'APP_ENV' => 'test',
+                ],
             );
             $client = new Client();
 
@@ -51,10 +54,9 @@ class ServerCommandTest extends KernelTestCase
         ]);
         $this->assertFalse($res->isError);
 
-        print_r($res); exit;
+        $content = $res->content[0]->text ?? '';
+        $data = json_decode($content, true);
 
-//        $resAsJson = json_encode($res, JSON_UNESCAPED_UNICODE);
-//        $this->assertStringContainsString('ISIN код', $resAsJson);
-//        $this->assertStringContainsString('RU0009029540', $resAsJson);
+        $this->assertSame('2019246368', $data['accountId']['value']);
     }
 }


### PR DESCRIPTION
### Summary
- добавлена фейковая реализация `OperationsServiceComponentInterface` для тестов
- настроен сервис в `services_test.yaml`
- расширен `.env.test` тестовыми переменными
- изменён тест `ServerCommandTest` для запуска команды в тестовом окружении и проверки результата

### Testing
- `./vendor/bin/phpunit --colors=never`


------
https://chatgpt.com/codex/tasks/task_e_684c3ee3b08c8320bd054ccfd85386b6