### PR TITLE
[codex] Fix nullable quotation handling

### DIFF
--- a/src/Component/OperationsService/ValueObject/QuotationVo.php
+++ b/src/Component/OperationsService/ValueObject/QuotationVo.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Component\OperationsService\ValueObject;
 
-use InvalidArgumentException;
 
 /**
  * Котировка - денежная сумма без указания валюты
@@ -19,14 +18,10 @@ readonly class QuotationVo
     ) {
     }
 
-    public static function createFromArray(array $data): self
+    public static function createFromArray(?array $data): self
     {
-        if (!isset($data['units']) && !isset($data['nano'])) {
-            throw new InvalidArgumentException('Invalid quotation data');
-        }
-
-        $units = (string)($data['units']);
-        $nano = (string)($data['nano']);
+        $units = (string)($data['units'] ?? 0);
+        $nano = (string)($data['nano'] ?? 0);
 
         $value = round((int)$units + (int)$nano / 1000000000, 9);
 

--- a/tests/Unit/Component/OperationsService/ValueObject/QuotationVoTest.php
+++ b/tests/Unit/Component/OperationsService/ValueObject/QuotationVoTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Component\OperationsService\ValueObject;
+
+use App\Component\OperationsService\ValueObject\QuotationVo;
+use PHPUnit\Framework\TestCase;
+
+class QuotationVoTest extends TestCase
+{
+    public function testCreateFromArrayWithNullData(): void
+    {
+        $vo = QuotationVo::createFromArray(null);
+        $this->assertSame(0.0, $vo->getValue());
+        $this->assertSame(0, $vo->getUnits());
+        $this->assertSame(0, $vo->getNano());
+    }
+
+    public function testCreateFromArrayWithValidData(): void
+    {
+        $vo = QuotationVo::createFromArray(['units' => 2, 'nano' => 500000000]);
+        $this->assertSame(2.5, $vo->getValue());
+        $this->assertSame(2, $vo->getUnits());
+        $this->assertSame(500000000, $vo->getNano());
+    }
+}


### PR DESCRIPTION
### Summary
- исправлена обработка null в `QuotationVo::createFromArray`
- добавлены unit-тесты для `QuotationVo`

### Testing
- `make phpcs` (ошибка: `No rule to make target 'phpcs'`)
- `make psalm` (ошибка: `No rule to make target 'psalm'`)
- `make tests` (сообщение: `Nothing to be done for 'tests'`)
- `./vendor/bin/phpunit --configuration phpunit.dist.xml`
```
PHPUnit 12.2.1 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.8
Configuration: /workspace/t-invest-mcp-server/phpunit.dist.xml

.........                                                           9 / 9 (100%)

Time: 00:00.243, Memory: 14.00 MB

OK (9 tests, 17 assertions)
```


------
https://chatgpt.com/codex/tasks/task_e_686620713d688320b6b52c00cc6ade42