### PR TITLE
[codex] Rename test command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,8 @@ fix: ## Автоматическое исправление кода (phpcbf)
 ###########
 #  Тесты  #
 ###########
-.PHONY: test
-test: ## Запустить тесты
+.PHONY: test-all
+test-all: ## Запустить тесты
 	$(COMPOSE) run --rm mcp-server bin/console cache:clear
 	$(COMPOSE) run --rm mcp-server bin/console -vv app:test
 	$(COMPOSE) run --rm mcp-server bin/phpunit

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ make help         # вывести справку
 make build        # собрать Docker-образ
 make push         # отправить образ в репозиторий
 make cache-clear  # очистить кэш приложения
-make test         # запустить тесты и пример клиента
+make test-all     # запустить тесты и пример клиента
 make tests        # запустить юнит тесты
 make psalm        # статический анализ
 make phpcs        # проверка стиля кода


### PR DESCRIPTION
### Summary
- переименовал цель `test` в `test-all` в Makefile
- обновил README для новой команды

### Testing
- `make phpcs`
- `make psalm`
- `make tests` *(fails: No code coverage driver available)*
- `./bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_686bb045cf548320b51ac9e0946741e1